### PR TITLE
CHRONO-012: Fix wrangler.toml duplicate vars configuration

### DIFF
--- a/workers/chrono-collectors/wrangler.toml
+++ b/workers/chrono-collectors/wrangler.toml
@@ -14,14 +14,19 @@ script_name = "chrono-collectors"
 # Enable Durable Objects migrations
 [[migrations]]
 tag = "v1"
-new_classes = ["PriceCollector"]
+new_sqlite_classes = ["PriceCollector"]
 
 # Development environment (default)
 [env.dev]
 name = "chrono-collectors-dev"
-vars = { WORKER_ID = "worker-dev" }
+
+[[env.dev.durable_objects.bindings]]
+name = "PRICE_COLLECTOR"
+class_name = "PriceCollector"
+script_name = "chrono-collectors-dev"
 
 [env.dev.vars]
+WORKER_ID = "worker-dev"
 API_BASE_URL = "http://localhost:3000"
 
 # Secrets (set via: wrangler secret put API_KEY --env dev)
@@ -30,9 +35,14 @@ API_BASE_URL = "http://localhost:3000"
 # Staging environment
 [env.staging]
 name = "chrono-collectors-staging"
-vars = { WORKER_ID = "worker-staging" }
+
+[[env.staging.durable_objects.bindings]]
+name = "PRICE_COLLECTOR"
+class_name = "PriceCollector"
+script_name = "chrono-collectors-staging"
 
 [env.staging.vars]
+WORKER_ID = "worker-staging"
 API_BASE_URL = "https://api-staging.projectchrono.io"
 
 # Secrets (set via: wrangler secret put API_KEY --env staging)
@@ -41,9 +51,14 @@ API_BASE_URL = "https://api-staging.projectchrono.io"
 # Production environment
 [env.production]
 name = "chrono-collectors-production"
-vars = { WORKER_ID = "worker-production" }
+
+[[env.production.durable_objects.bindings]]
+name = "PRICE_COLLECTOR"
+class_name = "PriceCollector"
+script_name = "chrono-collectors-production"
 
 [env.production.vars]
+WORKER_ID = "worker-production"
 API_BASE_URL = "https://chrono-api.hayven.xyz"
 
 # Custom domain routes for production


### PR DESCRIPTION
## Summary
Fix duplicate `vars` declarations in wrangler.toml that prevented Wrangler from deploying or running properly.

## Changes
- Consolidated duplicate `vars` declarations for dev, staging, and production environments
- Changed migrations to use `new_sqlite_classes` for free tier compatibility
- Added proper Durable Objects bindings for each environment

## Problem
The wrangler.toml file had duplicate `vars` declarations causing "Can't redefine existing key" errors.

## Testing
- [x] Wrangler configuration validates without errors
- [x] Ready for local testing with `wrangler dev`

## Related Issues
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)